### PR TITLE
Fix Gemspec/DevelopmentDependencies cop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,9 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in temml.gemspec
 gemspec
+
+gem 'bundler', '~> 2.0'
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.0'
+gem 'rubocop', '~> 1.0'
+gem 'simplecov', '~> 0.22.0'

--- a/temml.gemspec
+++ b/temml.gemspec
@@ -46,11 +46,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'execjs', '~> 2.7'
 
-  s.add_development_dependency 'bundler', '~> 2.0'
-  s.add_development_dependency 'rake', '~> 13.0'
-  s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'rubocop', '~> 1.0'
-  s.add_development_dependency 'simplecov', '~> 0.22.0'
-
   s.metadata['rubygems_mfa_required'] = 'false' # rubocop:disable Gemspec/RequireMFA
 end


### PR DESCRIPTION
Fix `Gemspec/DevelopmentDependencies` cop

This cop was introduced in rubocop 1.44, but didn't work correctly before 1.51.

rubocop documentation: https://github.com/rubocop/rubocop/blob/eeffa1000b5c0e14de417f2f0ed995ff8e3ff277/docs/modules/ROOT/pages/cops_gemspec.adoc#gemspecdevelopmentdependencies