### PR TITLE
Don't run "rake update" if imported version is already up to date

### DIFF
--- a/.github/workflows/upgrade-pr.yml
+++ b/.github/workflows/upgrade-pr.yml
@@ -22,6 +22,9 @@ jobs:
             echo "upstream_version=${upstream_version}"; \
             echo "newer_version=${newer_version}"; \
           } >> "$GITHUB_OUTPUT"
+          echo "current version: ${current_version}"
+          echo "upstream version: ${upstream_version}"
+          echo "newer_version: ${newer_version}"
       - name: Import Temml assets
         if: steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version
         run: |

--- a/.github/workflows/upgrade-pr.yml
+++ b/.github/workflows/upgrade-pr.yml
@@ -26,11 +26,15 @@ jobs:
           echo "upstream version: ${upstream_version}"
           echo "newer_version: ${newer_version}"
       - name: Import Temml assets
-        if: steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version
+        if: >
+          steps.check-versions.outputs.current_version != steps.check-versions.outputs.upstream_version &&
+          steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version
         run: |
           bundle exec rake "update[${{ steps.check-versions.outputs.newer_version }}]"
       - uses: peter-evans/create-pull-request@v5
-        if: steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version
+        if: >
+          steps.check-versions.outputs.current_version != steps.check-versions.outputs.upstream_version &&
+          steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version
         with:
           commit-message: rake update[${{ steps.check-versions.outputs.newer_version }}]
           branch: upgrade-temml-to-${{ steps.check-versions.outputs.newer_version }}


### PR DESCRIPTION
Don't run "rake update" if imported version is already up to date.