### PR TITLE
Revert "Fix CI (rubocop and rspec) workflow"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 jobs:
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit f144a086ff601c46d1390f4ab234962292343e42.

This PR removes 'main' from target branches because this restriction is redundant.