### PR TITLE
Trigger test workflows even when PR is automatically created

### DIFF
--- a/.github/workflows/upgrade-pr.yml
+++ b/.github/workflows/upgrade-pr.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           bundle exec rake "update[${{ steps.check-versions.outputs.newer_version }}]"
       - uses: peter-evans/create-pull-request@v5
+        id: create-pr
         if: >
           steps.check-versions.outputs.current_version != steps.check-versions.outputs.upstream_version &&
           steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version
@@ -46,3 +47,8 @@ jobs:
           body: Upgrade Temml to v${{ steps.check-versions.outputs.newer_version }}
           assignees: sudotac
           reviewers: sudotac
+      - name: Close and reopen the pull request
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        run: |
+          gh pr close ${{ steps.create-pr.outputs.pull-request-number }} -c "Close and reopen pull request to trigger workflows"
+          gh pr reopen ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
Test actions are not triggered by automatically created PRs due to GitHub restriction by default.
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

For simplicity, close and reopen the automatically created PR.