### PR TITLE
Enable manual trigger of workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 jobs:
   rubocop:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: lint and test
 on:
   push:
     branches:

--- a/.github/workflows/upgrade-pr.yml
+++ b/.github/workflows/upgrade-pr.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           bundle exec rake "update[${{ steps.check-versions.outputs.newer_version }}]"
       - uses: peter-evans/create-pull-request@v5
-        id: create-pr
         if: >
           steps.check-versions.outputs.current_version != steps.check-versions.outputs.upstream_version &&
           steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version
@@ -47,8 +46,3 @@ jobs:
           body: Upgrade Temml to v${{ steps.check-versions.outputs.newer_version }}
           assignees: sudotac
           reviewers: sudotac
-      - name: Close and reopen the pull request
-        if: steps.create-pr.outputs.pull-request-operation == 'created'
-        run: |
-          gh pr close ${{ steps.create-pr.outputs.pull-request-number }} -c "Close and reopen pull request to trigger workflows"
-          gh pr reopen ${{ steps.create-pr.outputs.pull-request-number }}

--- a/.github/workflows/upgrade-pr.yml
+++ b/.github/workflows/upgrade-pr.yml
@@ -2,6 +2,7 @@ name: Upgrade Temml if possible
 on:
   schedule:
     - cron: '30 18 * * 4'
+  workflow_dispatch:
 jobs:
   pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I misunderstood about workflows triggered by a workflow.
Closing and reopening the PR is completely meaningless...

There are [several ways](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs) to trigger a workflow by a workflow, but they all seem like abuse to me...

Then, I decided to trigger a workflow manually.
Don't forget to run the workflow before the review!