### PR TITLE
Fix some missing SPDX-License-Identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0 AND MIT
 /.bundle/
 /vendor/bundle/
 /.yardoc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0 AND MIT
 AllCops:
   NewCops: enable
   TargetRubyVersion: 3.0

--- a/.simplecov
+++ b/.simplecov
@@ -1,26 +1,6 @@
 # frozen_string_literal: true
 
-# The MIT License (MIT)
-#
-# Copyright (c) 2017 Gleb Mazovetskiy
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# SPDX-License-Identifier: CC0-1.0 AND MIT
 
 unless defined?(RUBY_ENGINE) && %w[rbx jruby].include?(RUBY_ENGINE)
   SimpleCov.start do


### PR DESCRIPTION
#41 added `SPDX-License-Identifier`, but forgot to add it to some dotfiles.