### PR TITLE
workflow: Bump peter-evans/create-pull-request to v6

### DIFF
--- a/.github/workflows/bump-pr.yml
+++ b/.github/workflows/bump-pr.yml
@@ -34,7 +34,7 @@ jobs:
         id: bump-version
         run: |
           bundle exec rake "bump[${{ steps.extract-version.outputs.next_version }}]"
-      - uses: peter-evans/create-pull-request@v5
+      - uses: peter-evans/create-pull-request@v6
         with:
           commit-message: rake bump[${{ steps.extract-version.outputs.next_version }}]
           branch: bump-to-${{ steps.extract-version.outputs.next_version }}

--- a/.github/workflows/upgrade-pr.yml
+++ b/.github/workflows/upgrade-pr.yml
@@ -38,7 +38,7 @@ jobs:
           steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version
         run: |
           bundle exec rake "update[${{ steps.check-versions.outputs.newer_version }}]"
-      - uses: peter-evans/create-pull-request@v5
+      - uses: peter-evans/create-pull-request@v6
         if: >
           steps.check-versions.outputs.current_version != steps.check-versions.outputs.upstream_version &&
           steps.check-versions.outputs.newer_version == steps.check-versions.outputs.upstream_version


### PR DESCRIPTION
peter-evans/create-pull-request v5 uses Node 16 and it is already end-of-life.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/