### PR TITLE
Drop support of Ruby 3.0

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.3', '3.2', '3.1', '3.0']
+        ruby-version: ['3.3', '3.2', '3.1']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.3', '3.2', '3.1', '3.0']
+        ruby-version: ['3.3', '3.2', '3.1']
     env:
       COVERAGE: '1'
     steps:


### PR DESCRIPTION
Ruby 3.0 will be EoL at 2024-03-31.