### PR TITLE
Drop support of Ruby 3.0 completely

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: CC0-1.0 AND MIT
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   Exclude:
     - 'tmp/**/*'
     - 'vendor/**/*'

--- a/lib/temml.rb
+++ b/lib/temml.rb
@@ -40,11 +40,11 @@ module Temml
         'temml.renderToString',
         math,
         displayMode: display_mode,
-        annotate: annotate,
-        leqno: leqno,
+        annotate:,
+        leqno:,
         throwOnError: throw_on_error,
         errorColor: error_color,
-        macros: macros,
+        macros:,
         **render_options
       )
     rescue ExecJS::ProgramError => e

--- a/temml.gemspec
+++ b/temml.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/sudotac/temml-ruby'
   s.license = 'CC0-1.0 AND MIT'
 
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 3.1'
 
   s.files = Dir['{exe,lib,vendor,license}/**/*'] + %w[COPYING.txt README.md]
   s.bindir = 'exe'


### PR DESCRIPTION
74fbd1f ("workflow: Drop support of Ruby 3.0") just removed Ruby 3.0 from test runner, and forgot to change gemspec and rubocop setting.