### PR TITLE
Rakefile: Fix regex of rake bump

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,8 +93,8 @@ task :bump, :version do |_task, args|
   # Update Gemfile example in README.md
   File.write('README.md',
              File.read('README.md')
-                 .gsub(/gem\s+'temml'\s*,\s*'~>\s*\S+'/,
-                       "gem 'temml', '~> #{version}'")
+                 .gsub(/gem\s+'temml'\s*,\s*'~>\s*\S+'\s*,\s*(.*),\s*:tag\s*=>\s*'v\S+'/,
+                       "gem 'temml', '~> #{version}', \\1, :tag => 'v#{version}'")
                  .gsub(/gem\s+specific_install\s+-t\s+v\S+/,
                        "gem specific_install -t v#{version}"))
 end


### PR DESCRIPTION
Gemfile example in README.md forgot to specify `:tag`.
Without `:tag`, HEAD of default branch (main) will be checked out. This is the problem when trying to use older version, so fix it. 