### PR TITLE
Fix license(s) attribute in gemspec

### DIFF
--- a/temml.gemspec
+++ b/temml.gemspec
@@ -15,7 +15,10 @@ Gem::Specification.new do |s|
   s.summary = 'Renders Temml from Ruby.'
   s.description = 'Exposes Temml server-side renderer to Ruby.'
   s.homepage = 'https://github.com/sudotac/temml-ruby'
-  s.license = 'CC0-1.0 AND MIT'
+
+  # 'CC0-1.0 AND MIT' is intended, but can't express precisely in the current spec of gemspec
+  # https://github.com/ruby/rubygems/issues/2713
+  s.licenses = ['CC0-1.0', 'MIT']
 
   s.required_ruby_version = '>= 3.2'
 


### PR DESCRIPTION
'CC0-1.0 AND MIT' is intended, but it is not accepted in license attribute as follows:

```
WARNING:  License identifier 'CC0-1.0 AND MIT' is invalid. Use an identifier from
https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
or set it to nil if you don't want to specify a license.
Did you mean 'CC0-1.0'?
```

Therefore, we use licenses attribute instead, though it is still ambiguous.

See also: https://github.com/ruby/rubygems/issues/2713